### PR TITLE
cache compiled pogo using a hash of its input as the key

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,35 @@ var pogo = require('pogo');
 var fs = require('fs');
 var through = require('through');
 var convert = require('convert-source-map');
+var checksum = require('checksum');
+var mkdirp = require('mkdirp');
+var cachePath = process.cwd() + "/.pogoCache/";
+
+mkdirp.sync(cachePath)
+
+function getCached(hash) {
+  if (fs.existsSync(cachePath + hash)) {
+    return fs.readFileSync(cachePath + hash, 'utf8');
+  }
+}
+
+function writeCache(hash, contents){
+  fs.writeFile(cachePath + hash, contents);
+}
 
 function compile(file, data) {
     var compiled = '';
     try {
-        compiled = pogo.compile(fs.readFileSync(file, 'utf8'));
+        var fileContents = fs.readFileSync(file, 'utf8');
+        var hash = checksum(fileContents);
+        cached = getCached(hash);
+        if (cached) {
+            compiled = cached;
+        }
+        else {
+            compiled = pogo.compile(fileContents);
+            writeCache(hash, compiled);
+        }
     }
     catch (e) {
         throw new Error("PogoScript compilation failed for '" + file + "'\n" + e.toString())

--- a/package.json
+++ b/package.json
@@ -4,16 +4,19 @@
   "description": "browserify v2 plugin for PogoScript with support for mixed .js and .pogo files",
   "main": "index.js",
   "dependencies": {
-    "through": "~2.2.0",
-    "convert-source-map": "~0.2.1"
+    "checksum": "^0.1.1",
+    "convert-source-map": "~0.2.1",
+    "mkdirp": "^0.5.0",
+    "through": "~2.2.0"
   },
   "peerDependencies": {
     "pogo": ""
   },
   "devDependencies": {
-    "tap": "~0.4.0",
     "browserify": "~2.4.0",
-    "pogo": ""
+    "fs-extra": "^0.16.3",
+    "pogo": "",
+    "tap": "^0.5.0"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -1,25 +1,54 @@
 var test = require('tap').test;
 var browserify = require('browserify');
 var vm = require('vm');
+var fs = require('fs-extra');
+var checksum = require('checksum');
+var pogo = require('pogo');
+
+var cachePath = __dirname+'/.pogoCache/';
 
 function bundle (file) {
     test('bundle transform', function (t) {
-        t.plan(1);
-        
-        var b = browserify();
-        b.add(__dirname + file);
-        b.transform(__dirname + '/..');
-        b.bundle(function (err, src) {
-            if (err) t.fail(err);
-            vm.runInNewContext(src, {
-                console: { log: log }
-            });
-        });
+        t.plan(2);
+        var filePath = __dirname + file;
+        fs.remove(cachePath, function(){
+          var b = browserify();
+          b.add(filePath);
+          b.transform(__dirname + '/..');
+          b.bundle(function (err, src) {
+              if (err) t.fail(err);
+              vm.runInNewContext(src, {
+                  console: { log: log }
+              });
+              t.test('caches input by hash', function(t){
+                t.plan(3);
+                var fileContents = fs.readFileSync(filePath, 'utf8');
+                var hash = checksum(fileContents);
+                var cachedFile = cachePath+hash;
+                t.ok(fs.existsSync(cachedFile), 'a compiled version of the file should be cached');
+                t.equal(fs.readFileSync(cachedFile, 'utf8'), pogo.compile(fileContents), 'cached file should be the compiled source');
 
-        function log (msg) {
-            t.equal(msg, 555);
-        }
+                t.test('uses cached file the next time it is requested', function(t){
+                  t.plan(1);
+                  var fakeCache = 'console.log("this is a cached file with fake content");';
+                  fs.writeFileSync(cachedFile, fakeCache);
+
+                  var b = browserify();
+                  b.add(filePath);
+                  b.transform(__dirname + '/..');
+                  b.bundle(function (err, src) {
+                    t.ok(src.indexOf(fakeCache) != -1, 'file should have been read from the cache');
+                  });
+                });
+              });
+          });
+
+          function log (msg) {
+              t.equal(msg, 555);
+          }
+        });
     });
+
 }
 
 bundle('/../example/foo.pogo');


### PR DESCRIPTION
This change stores compiled pogo in a folder called `.pogoCache` it hashes the inputs using a checksum and if it encounters the same checksum in future then it returns the pogo that has been previously compiled.

Downsides to this:
- the cache could get corrupted.
- For small files it may actually be quicker just to compile the pogo

It might be worth adding an option to enabled/disable caching so it can be disabled on things like CI?
And also maybe detect the input size and only cache over a certain limit? (may have to do some measuring for this)

Just want to get some feedback. I've found using this on our test runs reduced execution time from 1:14 to 0:44
